### PR TITLE
update vm size for dev-box VM

### DIFF
--- a/terraform/global/jumpboxes.tf
+++ b/terraform/global/jumpboxes.tf
@@ -88,7 +88,7 @@ resource "azurerm_linux_virtual_machine" "dev-box" {
     username = "farmer"
   }
   name = "dev-box.servrfarm.tech"
-  size = "Standard_D2as_v5"
+  size = "Standard_B2ms"
   os_disk {
     disk_size_gb = 32
     caching = "ReadWrite"


### PR DESCRIPTION
use `Standard_B2ms` since AMD cpu family quota is set to 0